### PR TITLE
Add billing and price formation for flat and time-of-use rates

### DIFF
--- a/examples/analysis/dsot/code/run_annual_postprocessing.py
+++ b/examples/analysis/dsot/code/run_annual_postprocessing.py
@@ -45,6 +45,13 @@ retail = False
 customer_cfs = False
 # dso_cfs = False
 
+# Determine the rate scenario to investigate
+# rate_scenario = None
+# rate_scenario = "flat"
+rate_scenario = "time-of-use"
+# rate_scenario = "subscription"
+# rate_scenario = "transactive"
+
 # Only set to True if you have already run cfs once and want to update billing to match expenses.
 squareup_revenue = True
 
@@ -436,9 +443,18 @@ if retail:
             required_revenue = (float(dso_df.loc[13, 'DSO_' + str(dso_num)]) + float(dso_df.loc[30, 'DSO_' + str(dso_num)])) * 1000
         else:
             required_revenue = 4e6
-        DSO_Cash_Flows, DSO_Revenues_and_Energy_Sales, tariff, surplus = \
-            rm.DSO_rate_making(case_path, dso_num, GLD_metadata, required_revenue,
-                               metadata_path, dso_scaling_factor, num_ind_cust, case_name, squareup_revenue)
+        DSO_Cash_Flows, DSO_Revenues_and_Energy_Sales, tariff, surplus = rm.DSO_rate_making(
+            case_path,
+            dso_num,
+            GLD_metadata,
+            required_revenue,
+            metadata_path,
+            dso_scaling_factor,
+            num_ind_cust,
+            case_name,
+            squareup_revenue,
+            rate_scenario,
+        )
 
         # Example of getting an annual customer bill in dictionary form:
         customer = list(GLD_metadata['billingmeters'].keys())[0]
@@ -488,8 +504,20 @@ if customer_cfs:
     customer_mean_df.to_csv(path_or_buf=case_path + '/Customer_CFS_Summary.csv')
 
 if dso_cfs:
-    DSO_df, CapitalCosts_dict_list, Expenses_dict_list, Revenues_dict_list, DSO_Cash_Flows_dict_list = \
-        hf.get_DSO_df(dso_range, generate_case_config, DSOmetadata, case_path, base_case_path)
+    (
+        DSO_df,
+        CapitalCosts_dict_list,
+        Expenses_dict_list,
+        Revenues_dict_list,
+        DSO_Cash_Flows_dict_list,
+    ) = hf.get_DSO_df(
+        dso_range,
+        generate_case_config,
+        DSOmetadata,
+        case_path,
+        base_case_path,
+        rate_scenario,
+    )
 
     DSO_df.to_csv(path_or_buf=case_path + '/DSO_CFS_Summary.csv')
 

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -108,7 +108,10 @@ def post_process():
                 day_range,
                 dso_scaling_factor,
                 metadata_path,
-                rate_scenario,
+                rate_scenario=rate_scenario,
+                tou_path=os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), case_config["dataPath"]
+                ),
             )
             print('Meter reading complete: DSO ' + str(dso_number) + ', Month ' + month_name)
             pt.toc()
@@ -171,13 +174,6 @@ def post_process():
     # bldg_stack_plots = False
     # forecast_plots = False
 
-    # Specify the rate scenario
-    # rate_scenario = None
-    rate_scenario = "flat"
-    # rate_scenario = "time-of-use"
-    # rate_scenario = "subscription"
-    # rate_scenario = "transactive"
-
     system_case = 'generate_case_config.json'
     first_data_day = 4  # First day in the simulation that data to be analyzed. Run-in days before this are discarded.
     discard_end_days = 1  # Number of days at the end of the simulation to be discarded
@@ -197,6 +193,12 @@ def post_process():
     check_folder = isdir(case_path + '/plots')
     if not check_folder:
         os.makedirs(case_path + '/plots')
+
+    # Identify the rate scenario
+    if "rate" in case_config:
+        rate_scenario = case_config["rate"]
+    else:
+        rate_scenario = None
 
     # STEP 1 --------- DSO Specific Post-Processing -------------------------
 
@@ -242,7 +244,7 @@ def post_process():
         for day_num in day_range:
             processlist.append([Daily_market_plot, day_num])
     
-    if create_baseline_demand_profiles and (rate_scenario == "time-of-use"):
+    if create_baseline_demand_profiles and (rate_scenario == "TOU"):
         for dso_num in dso_range:
             processlist.append([determine_baseline_demand_profiles, dso_num])
 

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -100,8 +100,23 @@ def post_process():
         # This function calculates the energy consumption every day for every customer and saves it to a h5 file.
         if read_meters:
             pt.tic()
-            meter_df, energysum_df = rm.read_meters(GLD_metadata, case_path, GLD_prefix, str(dso_number),
-                                                    day_range, dso_scaling_factor, metadata_path)
+            if time_of_use:
+                tou_params = pt.load_json(
+                    case_path + agent_prefix + str(dso_number),
+                    "time_of_use_parameters.json",
+                )
+            else:
+                tou_params = None
+            meter_df, energysum_df = rm.read_meters(
+                GLD_metadata,
+                case_path,
+                GLD_prefix,
+                str(dso_number),
+                day_range,
+                dso_scaling_factor,
+                metadata_path,
+                tou_params=tou_params,
+            )
             print('Meter reading complete: DSO ' + str(dso_number) + ', Month ' + month_name)
             pt.toc()
         # --------------- CALCULATE AMENITY SCORES  ------------------------------
@@ -122,6 +137,7 @@ def post_process():
     der_stack_plots = True
     bldg_stack_plots = True
     forecast_plots = True
+    time_of_use = True
     # read_meters = False
     # calc_amenity = False
     # pop_stats = False
@@ -129,6 +145,7 @@ def post_process():
     # der_stack_plots = False
     # bldg_stack_plots = False
     # forecast_plots = False
+    # time_of_use = False
 
     system_case = 'generate_case_config.json'
     first_data_day = 4  # First day in the simulation that data to be analyzed. Run-in days before this are discarded.

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -248,7 +248,7 @@ def post_process():
         for dso_num in dso_range:
             processlist.append([determine_baseline_demand_profiles, dso_num])
 
-    if create_demand_profiles and (rate_scenario == "subscription"):
+    if create_demand_profiles and (rate_scenario == "DNR"):
         for dso_num in dso_range:
             processlist.append([determine_demand_profiles, dso_num])
 

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -100,13 +100,6 @@ def post_process():
         # This function calculates the energy consumption every day for every customer and saves it to a h5 file.
         if read_meters:
             pt.tic()
-            if time_of_use:
-                tou_params = pt.load_json(
-                    case_path + agent_prefix + str(dso_number),
-                    "time_of_use_parameters.json",
-                )
-            else:
-                tou_params = None
             meter_df, energysum_df = rm.read_meters(
                 GLD_metadata,
                 case_path,
@@ -115,7 +108,7 @@ def post_process():
                 day_range,
                 dso_scaling_factor,
                 metadata_path,
-                tou_params=tou_params,
+                rate_scenario,
             )
             print('Meter reading complete: DSO ' + str(dso_number) + ', Month ' + month_name)
             pt.toc()
@@ -137,7 +130,6 @@ def post_process():
     der_stack_plots = True
     bldg_stack_plots = True
     forecast_plots = True
-    time_of_use = True
     # read_meters = False
     # calc_amenity = False
     # pop_stats = False
@@ -145,7 +137,13 @@ def post_process():
     # der_stack_plots = False
     # bldg_stack_plots = False
     # forecast_plots = False
-    # time_of_use = False
+
+    # Specify the rate scenario
+    # rate_scenario = None
+    rate_scenario = "flat"
+    # rate_scenario = "time-of-use"
+    # rate_scenario = "subscription"
+    # rate_scenario = "transactive"
 
     system_case = 'generate_case_config.json'
     first_data_day = 4  # First day in the simulation that data to be analyzed. Run-in days before this are discarded.

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -128,7 +128,7 @@ def post_process():
             dso_number,
             year_num,
             month_num,
-            day_range,
+            list(day_range),
             save=False,
         )
 
@@ -148,7 +148,7 @@ def post_process():
             dso_number,
             year_num,
             month_num,
-            day_range,
+            list(day_range),
             save=True,
         )
 

--- a/src/tesp_support/tesp_support/dsot/Wh_Energy_Purchases.py
+++ b/src/tesp_support/tesp_support/dsot/Wh_Energy_Purchases.py
@@ -141,7 +141,7 @@ def load_price_data(dir_path, market_type, dso_num, simdata, place):
     return prices_data
 
 
-def Wh_Energy_Purchases(dir_path, dso_num, simdata=False, h1=5, h2=16, h3=20, place='Houston'):
+def Wh_Energy_Purchases(dir_path, dso_num, simdata=False, h1=5, h2=16, h3=20, place='Houston', monthly_data=False):
     """ Computes the total costs, total energy purchases and average price annually for bilateral,
     day-ahead and real-time markets from hourly and 5 min ERCOT energy and price data.
 
@@ -292,10 +292,24 @@ def Wh_Energy_Purchases(dir_path, dso_num, simdata=False, h1=5, h2=16, h3=20, pl
                                    WhBLPurchasesMonthly, WhDAPurchasesMonthly, WhRTPurchasesMonthly,
                                    WhBLPriceMonthly, WhDAPriceMonthly, WhRTPriceMonthly], axis=1)
 
-    Monthly_Purchases.rename(columns={'Fixed Quantity (MW)': 'Bilateral (MWh)', ' Bus1': 'Real-time (MWh)',
-                                      0: 'Bilateral Purchases ($)', 1: 'Day-ahead ($)', 2: 'Real-time ($)',
-                                      3: 'Bilateral Avg Price ($/MWh)', 4: 'Day-ahead Avg Price ($/MWh)',
-                                      5: 'Real-time Avg Price ($/MWh)'}, inplace=True)
+    Monthly_Purchases.rename(
+        columns={
+            "Fixed Quantity (MW)": "Bilateral Energy (MWh)",
+            "Day-ahead (MWh)": "Day-Ahead Energy (MWh)",
+            0: "Real-Time Energy (MWh)",
+            1: "Bilateral Purchases ($)",
+            2: "Day-Ahead Purchases ($)",
+            3: "Real-Time Purchases ($)",
+            4: "Bilateral Average Price ($/MWh)",
+            5: "Day-Ahead Average Price ($/MWh)",
+            6: "Real-Time Average Price ($/MWh)",
+        },
+        inplace=True,
+    )
+
+    # Return the monthly data instead of the annual data, if prompted by the user
+    if monthly_data:
+        return Monthly_Purchases
 
     # TO DO: Change the following path for the monthly purchases csv to the desired location
     # Monthly_Purchases.to_csv(r'C:/Users/mayh819/PycharmProjects/tesp-private/tesp-private/{}_DSO_{}_Monthly_Purchases.csv'.format(place,dso_num))

--- a/src/tesp_support/tesp_support/dsot/dso_CFS.py
+++ b/src/tesp_support/tesp_support/dsot/dso_CFS.py
@@ -955,6 +955,11 @@ def dso_CFS(
         'Balance': 0
     }
 
+    # Add the monthly DSO capital and operating expenses to the composite cash flows dict
+    for m in months:
+        DSO_Cash_Flows_composite["CapitalExpenses_" + m] = CapitalExpensesMonthly[m]
+        DSO_Cash_Flows_composite["OperatingExpenses_" + m] = OperatingExpensesMonthly[m]
+
     # DSO_Cash_Flows_DO
     # DSO_Cash_Flows_MO
     # DSO_Cash_Flows_RSP

--- a/src/tesp_support/tesp_support/dsot/dso_CFS.py
+++ b/src/tesp_support/tesp_support/dsot/dso_CFS.py
@@ -381,10 +381,29 @@ def dso_CFS(
     for m in months:
         WhISOMonthly[m] = iso_energy_fee * EnergyQuantityPurchasedMonthly_base_case[m] / 1000
 
-    RetailDAEnergy = dso_helper.returnDictSum(
-        DSO_Revenues_and_Energy_Sales['RetailSales']['TransactiveSales']['RetailDAEnergy'])
-    RetailRTEnergy = dso_helper.returnDictSum(
-        DSO_Revenues_and_Energy_Sales['RetailSales']['TransactiveSales']['RetailRTEnergy'])
+    if rate_scenario is None:
+        RetailDAEnergy = dso_helper.returnDictSum(
+            DSO_Revenues_and_Energy_Sales['RetailSales']['TransactiveSales']['RetailDAEnergy'])
+        RetailRTEnergy = dso_helper.returnDictSum(
+            DSO_Revenues_and_Energy_Sales['RetailSales']['TransactiveSales']['RetailRTEnergy'])
+    else:
+        if rate_scenario == "transactive":
+            RetailDAEnergy = sum(
+                DSO_Revenues_and_Energy_Sales["RetailSales"]["TransactiveSales" + c][
+                    "RetailDAEnergy" + c
+                ]
+                for c in ["Res", "Comm", "Ind"]
+            )
+            RetailRTEnergy = sum(
+                DSO_Revenues_and_Energy_Sales["RetailSales"]["TransactiveSales" + c][
+                    "RetailRTEnergy" + c
+                ]
+                for c in ["Res", "Comm", "Ind"]
+            )
+        else:
+            RetailDAEnergy = 0
+            RetailRTEnergy = 0
+
     TransactFees = metadata_general['dso_transaction_fee_per_KWh'] * (RetailDAEnergy + RetailRTEnergy) / 1000 * 1000
 
     EnergySold = DSO_Revenues_and_Energy_Sales['EnergySold']

--- a/src/tesp_support/tesp_support/dsot/dso_helper_functions.py
+++ b/src/tesp_support/tesp_support/dsot/dso_helper_functions.py
@@ -360,7 +360,14 @@ def get_mean_for_diff_groups(df, main_variables, variables_combs, cfs_start_posi
     return customer_mean_df
 
 
-def get_DSO_df(dso_range, case_config, DSOmetadata, case_path, base_case_path):
+def get_DSO_df(
+    dso_range,
+    case_config,
+    DSOmetadata,
+    case_path,
+    base_case_path,
+    rate_scenario=None,
+):
     DSO_df = pd.DataFrame([])
     CapitalCosts_dict_list = []
     Expenses_dict_list = []
@@ -384,11 +391,26 @@ def get_DSO_df(dso_range, case_config, DSOmetadata, case_path, base_case_path):
         DSO_base_case_peak_demand = Market_Purchases_base_case['WhEnergyPurchases']['WholesalePeakLoadRate']
 
 
-        CapitalCosts_dict, Expenses_dict, Revenues_dict, DSO_Cash_Flows_dict, \
-            DSO_Wholesale_Energy_Purchase_Summary, DSO_Cash_Flows_composite = \
-                cfs.dso_CFS(case_config, DSOmetadata, str(dso_num), DSO_peak_demand, DSO_base_case_peak_demand,
-                            System_peak_reduction_fraction, DSO_Cash_Flows, DSO_Revenues_and_Energy_Sales,
-                            Market_Purchases, Market_Purchases_base_case)
+        (
+            CapitalCosts_dict,
+            Expenses_dict,
+            Revenues_dict,
+            DSO_Cash_Flows_dict,
+            DSO_Wholesale_Energy_Purchase_Summary,
+            DSO_Cash_Flows_composite,
+        ) = cfs.dso_CFS(
+            case_config,
+            DSOmetadata,
+            str(dso_num),
+            DSO_peak_demand,
+            DSO_base_case_peak_demand,
+            System_peak_reduction_fraction,
+            DSO_Cash_Flows,
+            DSO_Revenues_and_Energy_Sales,
+            Market_Purchases,
+            Market_Purchases_base_case,
+            rate_scenario,
+        )
         CapitalCosts_dict_list.append(CapitalCosts_dict)
         Expenses_dict_list.append(Expenses_dict)
         Revenues_dict_list.append(Revenues_dict)
@@ -405,9 +427,9 @@ def get_DSO_df(dso_range, case_config, DSOmetadata, case_path, base_case_path):
             "DSO_peak_demand": Market_Purchases['WhEnergyPurchases']['WholesalePeakLoadRate'],
             "DSO_base_case_peak_demand": Market_Purchases_base_case['WhEnergyPurchases']['WholesalePeakLoadRate'],
             "energy_sold_MWh": DSO_Revenues_and_Energy_Sales['EnergySold'],
-            "energy_purchased_MWh":  Market_Purchases['WhEnergyPurchases']['WhDAPurchases']['WhDAEnergy']
-                                     + Market_Purchases['WhEnergyPurchases']['WhRTPurchases']['WhRTEnergy']
-                                     + Market_Purchases['WhEnergyPurchases']['WhBLPurchases']['WhBLEnergy'],
+            "energy_purchased_MWh": Market_Purchases['WhEnergyPurchases']['WhDAPurchases']['WhDAEnergy']
+                                    + Market_Purchases['WhEnergyPurchases']['WhRTPurchases']['WhRTEnergy']
+                                    + Market_Purchases['WhEnergyPurchases']['WhBLPurchases']['WhBLEnergy'],
             'EffectiveCostRetailEnergy': DSO_Revenues_and_Energy_Sales['EffectiveCostRetailEnergy']
         }
         DSO_col.update(DSO_Cash_Flows_composite)

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -645,22 +645,6 @@ def calculate_consumer_bills(
         load sector.
     """
 
-    # Specify a conversion between month name abbreviations and month numbers
-    month_name_to_num = {
-        "Jan": 1,
-        "Feb": 1,
-        "Mar": 3,
-        "Apr": 4,
-        "May": 5,
-        "Jun": 6,
-        "Jul": 7,
-        "Aug": 8,
-        "Sep": 9,
-        "Oct": 10,
-        "Nov": 11,
-        "Dec": 12,
-    }
-
     # Load in necessary data for the defined rate scenario
     if rate_scenario == "time-of-use":
         # Note: this assumes each month has the same number of time-of-use periods
@@ -741,10 +725,10 @@ def calculate_consumer_bills(
                 if rate_scenario == "time-of-use":
                     # Calculate the consumer's energy charge under the time-of-use tariff
                     bill_df.loc[(each, "tou_energy_charge"), m] = sum(
-                        tou_params[month_name_to_num[m]]["price"]
-                        * tou_params[month_name_to_num[m]]["periods"][k]["ratio"]
+                        tou_params[m]["price"]
+                        * tou_params[m]["periods"][k]["ratio"]
                         * meter_df.loc[(each, k + "_kwh"), m]
-                        for k in tou_params[month_name_to_num[m]]["periods"].keys()
+                        for k in tou_params[m]["periods"].keys()
                     ) + calculate_tier_credit(
                         metadata["billingmeters"][each]["tariff_class"],
                         tariff,
@@ -752,10 +736,10 @@ def calculate_consumer_bills(
                     )
 
                     # Calculate the consumer's energy charge for each time-of-use period
-                    for k in tou_params[month_name_to_num[m]]["periods"].keys():
+                    for k in tou_params[m]["periods"].keys():
                         bill_df.loc[(each, "tou_" + k + "_energy_charge"), m] = (
-                            tou_params[month_name_to_num[m]]["price"]
-                            * tou_params[month_name_to_num[m]]["periods"][k]["ratio"]
+                            tou_params[m]["price"]
+                            * tou_params[m]["periods"][k]["ratio"]
                             * meter_df.loc[(each, k + "_kwh"), m]
                         )
 
@@ -780,7 +764,7 @@ def calculate_consumer_bills(
                     ]
 
                     # Store the total energy purchased during each time-of-use period
-                    for k in tou_params[month_name_to_num[m]]["periods"].keys():
+                    for k in tou_params[m]["periods"].keys():
                         bill_df.loc[
                             (each, "tou_" + k + "_energy_purchased"), m
                         ] = meter_df.loc[(each, k + "_kwh"), m]

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1799,8 +1799,8 @@ def DSO_rate_making(
         file_name = 'rate_case_values_' + case_name + '.json'
     
     # Specify the Tariff file name for scenarios related to the rates scenarios project
-    if (rate_scenario is None) and (case_name == ""):
-        case_name = "rate_case_values_" + rate_scenario + ".json"
+    if (rate_scenario is not None) and (case_name == ""):
+        file_name = "rate_case_values_" + rate_scenario + ".json"
 
     # Load Tariff structure
     tariff = load_json(tariff_path, file_name)

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -491,7 +491,7 @@ def create_demand_profiles_for_each_meter(
     demand_df.set_index(index, inplace=True)
 
     # Convert to an hourly profile
-    demand_df = demand_df.resample("H").sum().div(12)
+    demand_df = demand_df.resample("H").sum().div(1000).div(12)
 
     # Save the demand data, if specified
     if save:

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -836,53 +836,53 @@ def calculate_consumer_bills(
                                 (each, component), m
                             ]
 
-        # Calculate the totals across all consumer classes
-        for component in bill_components:
-            if "average_price" not in component:
-                for load in ["residential", "commercial", "industrial"]:
-                    billsum_df.loc[("total", component), :] += billsum_df.loc[
-                        (load, component), :
-                    ]
+    # Calculate the totals across all consumer classes
+    for component in bill_components:
+        if "average_price" not in component:
+            for load in ["residential", "commercial", "industrial"]:
+                billsum_df.loc[("total", component), :] += billsum_df.loc[
+                    (load, component), :
+                ]
 
-        # Calculate the annual sums
-        bill_df["sum"] = bill_df.loc[
-            :, bill_df.columns[~bill_df.columns.str.contains("sum")]
-        ].sum(axis=1)
-        billsum_df["sum"] = billsum_df.loc[
-            :, billsum_df.columns[~billsum_df.columns.str.contains("sum")]
-        ].sum(axis=1)
+    # Calculate the annual sums
+    bill_df["sum"] = bill_df.loc[
+        :, bill_df.columns[~bill_df.columns.str.contains("sum")]
+    ].sum(axis=1)
+    billsum_df["sum"] = billsum_df.loc[
+        :, billsum_df.columns[~billsum_df.columns.str.contains("sum")]
+    ].sum(axis=1)
 
-        # Calculate the average prices at the meter level
-        for each in metadata["billingmeters"]:
-            bill_df.loc[(each, "flat_average_price"), "sum"] = (
-                bill_df.loc[(each, "flat_total_charge"), "sum"]
-                / bill_df.loc[(each, "flat_energy_purchased"), "sum"]
+    # Calculate the average prices at the meter level
+    for each in metadata["billingmeters"]:
+        bill_df.loc[(each, "flat_average_price"), "sum"] = (
+            bill_df.loc[(each, "flat_total_charge"), "sum"]
+            / bill_df.loc[(each, "flat_energy_purchased"), "sum"]
+        )
+        if rate_scenario == "time-of-use":
+            bill_df.loc[(each, "tou_average_price"), "sum"] = (
+                bill_df.loc[(each, "tou_total_charge"), "sum"]
+                / bill_df.loc[(each, "tou_energy_purchased"), "sum"]
             )
-            if rate_scenario == "time-of-use":
-                bill_df.loc[(each, "tou_average_price"), "sum"] = (
-                    bill_df.loc[(each, "tou_total_charge"), "sum"]
-                    / bill_df.loc[(each, "tou_energy_purchased"), "sum"]
-                )
-            elif rate_scenario == "subscription":
-                None
-            elif rate_scenario == "transactive":
-                None
+        elif rate_scenario == "subscription":
+            None
+        elif rate_scenario == "transactive":
+            None
         
-        # Calculate the average prices at the sector level
-        for load in ["residential", "commercial", "industrial", "total"]:
-            billsum_df.loc[(load, "flat_average_price")] = (
-                billsum_df.loc[(load, "flat_total_charge")]
-                / billsum_df.loc[(load, "flat_energy_purchased")]
+    # Calculate the average prices at the sector level
+    for load in ["residential", "commercial", "industrial", "total"]:
+        billsum_df.loc[(load, "flat_average_price")] = (
+            billsum_df.loc[(load, "flat_total_charge")]
+            / billsum_df.loc[(load, "flat_energy_purchased")]
+        )
+        if rate_scenario == "time-of-use":
+            billsum_df.loc[(load, "tou_average_price")] = (
+                billsum_df.loc[(load, "tou_total_charge")]
+                / billsum_df.loc[(load, "tou_energy_purchased")]
             )
-            if rate_scenario == "time-of-use":
-                billsum_df.loc[(load, "tou_average_price")] = (
-                    billsum_df.loc[(load, "tou_total_charge")]
-                    / billsum_df.loc[(load, "tou_energy_purchased")]
-                )
-            elif rate_scenario == "subscription":
-                None
-            elif rate_scenario == "transactive":
-                None
+        elif rate_scenario == "subscription":
+            None
+        elif rate_scenario == "transactive":
+            None
 
     # Return the bill DataFrames
     return bill_df, billsum_df

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -55,7 +55,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
 
         # Add consumtpion during time-of-use periods, if applicable
         if tou_params is not None:
-            for k in tou_params.keys():
+            for k in tou_params["periods"].keys():
                 meter.append(each)
                 variable.append(k + "_kwh")
                 month.append(0)
@@ -107,7 +107,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
         
         # Add consumtpion during time-of-use periods, if applicable
         if tou_params is not None:
-            for k in tou_params.keys():
+            for k in tou_params["periods"].keys():
                 loads.append(each)
                 variable.append(k + "_kwh")
                 month.append(0)
@@ -166,18 +166,18 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
             
             # Calculate each consumer's time-of-use-related consumption metrics, if applicable
             if tou_params is not None:
-                for k in tou_params.keys():
-                    for t in range(len(tou_params[k]["hour_start"])):
+                for k in tou_params["periods"].keys():
+                    for t in range(len(tou_params["periods"][k]["hour_start"])):
                         meter_df.loc[(each, k + "_kwh"), day_name] += (
                             temp.loc[
                                 (
                                     300
                                     * 12
-                                    * (24 * (day - 1) + tou_params[k]["hour_start"][t])
+                                    * (24 * (day - 1) + tou_params["periods"][k]["hour_start"][t])
                                 ) : (
                                     300
                                     * 12
-                                    * (24 * (day - 1) + tou_params[k]["hour_end"][t])
+                                    * (24 * (day - 1) + tou_params["periods"][k]["hour_end"][t])
                                     - 1
                                 ),
                                 "real_power_avg",
@@ -185,7 +185,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
                             / 1000
                             / 12
                         )
-                        if tou_params[k]["hour_start"][t] == 0:
+                        if tou_params["periods"][k]["hour_start"][t] == 0:
                             meter_df.loc[(each, k + "_kwh"), day_name] += (
                                 temp.loc[300 * 12 * 24 * day, "real_power_avg"]
                                 / 1000
@@ -233,7 +233,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
                     
                     # Calculate the time-of-use-related metrics, if applicable
                     if tou_params is not None:
-                        for k in tou_params.keys():
+                        for k in tou_params["periods"].keys():
                             energysum_df.loc[(load, k + "_kwh"), day_name] += (
                                 meter_df.loc[(each, k + "_kwh"), day_name] * SF
                             )
@@ -259,7 +259,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
     # Create totals for energy metrics
     energysum_metrics = ['kw-hr', 'demand_quantity', 'da_q', 'rt_q', 'congest_$', 'congest_q']
     if tou_params is not None:
-        for k in tou_params.keys():
+        for k in tou_params["periods"].keys():
             energysum_metrics.append(k + "_kwh")
     for item in energysum_metrics:
         for load in ['residential', 'commercial', 'industrial']:
@@ -281,7 +281,7 @@ def read_meters(metadata, dir_path, folder_prefix, dso_num, day_range, SF, dso_d
             meter_df.loc[(each, 'load_factor'), 'sum'] = 0
     
     if tou_params is not None:
-        for k in tou_params.keys():
+        for k in tou_params["periods"].keys():
             meter_df.loc[(slice(None), k + "_kwh"), ["sum"]] = meter_df.loc[
                 (slice(None), k + "_kwh"),
                 meter_df.columns[~meter_df.columns.isin(["sum"])],

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1387,7 +1387,6 @@ def calculate_tariff_prices(
     dso_num,
     sf,
     num_ind_cust,
-    year,
     rate_scenario,
 ):
     """Determines the prices that ensure enough revenue is collected to recover the 

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1109,7 +1109,7 @@ def calculate_consumer_bills(
                     # Calculate the consumer's tier credit (due to the declining block)
                     # rate, if the consumer is eligible
                     if metadata["billingmeters"][each]["tariff_class"] in [
-                        "residential",
+                        #"residential",
                         "commercial",
                         "industrial",
                     ]:
@@ -1177,7 +1177,7 @@ def calculate_consumer_bills(
                 # Calculate the consumer's tier credit (due to the declining block)
                 # rate, if the consumer is eligible
                 if metadata["billingmeters"][each]["tariff_class"] in [
-                    "residential",
+                    #"residential",
                     "commercial",
                     "industrial",
                 ]:
@@ -1222,7 +1222,7 @@ def calculate_consumer_bills(
             # Calculate the totals for each consumer class except for industrial
             # consumers, which are calculated separately below
             if metadata["billingmeters"][each]["tariff_class"] in [
-                "residential",
+                #"residential",
                 "commercial",
             ]:
                 for component in bill_components:
@@ -1428,7 +1428,7 @@ def calculate_tariff_prices(
             # Calculate the necessary rate components for residential and commercial
             # consumers
             if metadata["billingmeters"][each]["tariff_class"] in [
-                "residential",
+                #"residential",
                 "commercial",
             ]:
                 # Update total consumption
@@ -1449,7 +1449,7 @@ def calculate_tariff_prices(
 
                 # Update the total tier credit, if the consumer qualifies
                 if metadata["billingmeters"][each]["tariff_class"] in [
-                    "residential",
+                    #"residential",
                     "commercial",
                 ]:
                     total_tier_credit_rc += sum(
@@ -1542,7 +1542,7 @@ def calculate_tariff_prices(
                 # Update the total tier credit for each consumer during each season, if 
                 # the consumer qualifies
                 if metadata["billingmeters"][each]["tariff_class"] in [
-                    "residential",
+                    #"residential",
                     "commercial",
                     "industrial",
                 ]:
@@ -1587,7 +1587,7 @@ def calculate_tariff_prices(
                         # Calculate the consumer's tier credit (due to the declining 
                         # block) rate, if the consumer is eligible
                         if metadata["billingmeters"][each]["tariff_class"] in [
-                            "residential",
+                            #"residential",
                             "commercial",
                             "industrial",
                         ]:
@@ -1635,7 +1635,7 @@ def calculate_tariff_prices(
                 # Update the total tier credit for the flat rate consumers, if the 
                 # consumer qualifies
                 if metadata["billingmeters"][each]["tariff_class"] in [
-                    "residential",
+                    #"residential",
                     "commercial",
                     "industrial",
                 ]:

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1572,9 +1572,10 @@ def get_total_dso_costs(case_path, dso_num, rate_scenario, seasons_dict=None):
             if dso_df is None:
                 dso_expenses[s] = 1e10 / num_seasons
             else:
-                dso_expenses[s] = 1000 * (
-                    float(dso_df.loc["CapitalExpenses_" + s, "DSO_" + dso_num])
-                    + float(dso_df.loc["OperatingExpenses_" + s, "DSO_" + dso_num])
+                dso_expenses[s] = 1000 * sum(
+                    float(dso_df.loc["CapitalExpenses_" + m, "DSO_" + dso_num])
+                    + float(dso_df.loc["OperatingExpenses_" + m, "DSO_" + dso_num])
+                    for m in seasons_dict[s]
                 )
     elif rate_scenario == "subscription":
         # Note that this assumes the subscription price is based on a time-of-use rate
@@ -1584,9 +1585,10 @@ def get_total_dso_costs(case_path, dso_num, rate_scenario, seasons_dict=None):
             if dso_df is None:
                 dso_expenses[s] = 1e10 / num_seasons
             else:
-                dso_expenses[s] = 1000 * (
-                    float(dso_df.loc["CapitalExpenses_" + s, "DSO_" + dso_num])
-                    + float(dso_df.loc["OperatingExpenses_" + s, "DSO_" + dso_num])
+                dso_expenses[s] = 1000 * sum(
+                    float(dso_df.loc["CapitalExpenses_" + m, "DSO_" + dso_num])
+                    + float(dso_df.loc["OperatingExpenses_" + m, "DSO_" + dso_num])
+                    for m in seasons_dict[s]
                 )
     elif rate_scenario == "transactive":
         if dso_df is None:


### PR DESCRIPTION
This PR introduces two main additions to the postprocessing code:
1. Allows billing information for consumers and DSOs at the aggregate level to be calculated for the flat and time-of-use rates. This not only includes calculating the billing information, but also discovering the prices used to calculate the billing information per cost-of-service regulation principles.
2. Updates the case postprocessing script (`run_case_postprocessing.py`) to collect necessary information for the time-of-use and subscription rates. Namely, this allows period-specific metrics to be collected (e.g., off-peak-period and peak-period energy consumption) and enables the creation of demand and baseline demand profiles, both of which are necessary for the calculation of bills under the subscription rate.

To enable these changes, the following files are changed as follows:
- `dso_rate_making.py` updates `read_meters` to allow period-specific metrics under the time-of-use rate to be calculated, includes functionality to calculate hourly demand and baseline demand profiles for each meter (`create_demand_profiles_for_each_meter` and `create_baseline_demand_profiles_for_each_meter`, respectively), calculates billing information for consumers in the flat and time-of-use rate scenarios (`calculate_consumer_bills`), and determines the tariff prices needed to recover DSO expenses using a closed-form solution (`calculate_tariff_prices`). `DSO_rate_making` is preserved in a way that allows the rate information for each rate scenario to be determined or allows rate information for the original DSO+T implementation to be determined.
- `dso_cfs.py` updates the calculation of the DSO CFS to return capital and operating expenses that can be attributed to each month, which is needed to determine the expense-recovering prices in the time-of-use and subscription rates.
- `Wh_Energy_Purchases.py` allows the monthly energy purchases from the wholesale market to be accessed, which is needed in `dso_CFS`.
- `dso_helper_functions.py` allows the rate scenario under investigation to be specified
- `run_annual_postprocessing.py` allows the rate scenario under investigation to be specified.
- `run_case_postprocessing.py` allows the rate scenario under investigation to be specified and allows demand and baseline demand profiles to be calculated and saved depending on the rate scenario.

All feedback is welcome, though I would especially appreciate feedback on some things in `run_case_postprocessing.py` in particular. Since this runs on the cluster, I am less familiar with the directory structure. What is the best way for the people who are running this script to include information on the rate scenario and the time-of-use parameters?
- I currently have the rate scenario being specified through a hard-coded parameter in the case postprocessing script. Is there a better way to do this? Is there a metadata-like file in which this information might already be specified?
- I have the time-of-use rate parameters stored in a .json file and structured in a way that includes the parameters for each month in each DSO. This allows the time-of-use rate parameters file to be stored in each scenario's root directory (i.e., where the folders for each month's run and other summary files are located) when performing the regular postprocessing. However, I'm not sure how this is structured for case postprocessing. Since the case postprocessing script appears to define file paths differently from the other postprocessing scripts, I ended up making it so that the time-of-use parameters file needs to be included in the directory for each month's run. This seems inefficient though, especially because this file would need to be uploaded to each month prior to running the case postprocessing script. Is there a better place that I should indicate that this file will be stored?