### PR TITLE
Add bill calculation and price discovery for transactive and DSO+T rates

### DIFF
--- a/examples/analysis/dsot/code/run_annual_postprocessing.py
+++ b/examples/analysis/dsot/code/run_annual_postprocessing.py
@@ -444,6 +444,7 @@ if retail:
             required_revenue = (float(dso_df.loc[13, 'DSO_' + str(dso_num)]) + float(dso_df.loc[30, 'DSO_' + str(dso_num)])) * 1000
         else:
             required_revenue = 4e6
+        trans_cost_balance_method = None
         DSO_Cash_Flows, DSO_Revenues_and_Energy_Sales, tariff, surplus = rm.DSO_rate_making(
             case_path,
             dso_num,
@@ -455,6 +456,7 @@ if retail:
             case_name,
             squareup_revenue,
             rate_scenario,
+            trans_cost_balance_method,
         )
 
         # Example of getting an annual customer bill in dictionary form:

--- a/examples/analysis/dsot/code/run_annual_postprocessing.py
+++ b/examples/analysis/dsot/code/run_annual_postprocessing.py
@@ -51,6 +51,7 @@ customer_cfs = False
 rate_scenario = "time-of-use"
 # rate_scenario = "subscription"
 # rate_scenario = "transactive"
+# rate_scenario = "dsot"
 
 # Only set to True if you have already run cfs once and want to update billing to match expenses.
 squareup_revenue = True

--- a/examples/analysis/dsot/code/run_case_postprocessing.py
+++ b/examples/analysis/dsot/code/run_case_postprocessing.py
@@ -126,8 +126,6 @@ def post_process():
         demand_df = rm.create_demand_profiles_for_each_meter(
             case_path,
             dso_number,
-            year_num,
-            month_num,
             list(day_range),
             save=False,
         )
@@ -146,8 +144,6 @@ def post_process():
         demand_df = rm.create_demand_profiles_for_each_meter(
             case_path,
             dso_number,
-            year_num,
-            month_num,
             list(day_range),
             save=True,
         )
@@ -219,10 +215,6 @@ def post_process():
         + timedelta(days=first_data_day)
     ).month
     month_name = month_dict[month_num]
-    year_num = (
-        datetime.strptime(case_config["StartTime"], "%Y-%m-%d %H:%M:%S")
-        + timedelta(days=first_data_day)
-    ).year
 
     day_range = range(first_data_day, num_sim_days - discard_end_days + 1)
 

--- a/src/tesp_support/tesp_support/dsot/dso_CFS.py
+++ b/src/tesp_support/tesp_support/dsot/dso_CFS.py
@@ -1002,9 +1002,13 @@ def dso_CFS(
             DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]
         )
         elif rate_scenario == "transactive":
-            OtherRateSales = 0
+            OtherRateSales = dso_helper.returnDictSum(
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"]
+        )
         elif rate_scenario == "dsot":
-            OtherRateSales = 0
+            OtherRateSales = dso_helper.returnDictSum(
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"]
+        )
 
         # Determine the total retail sales
         RetailSales = FlatSales + OtherRateSales
@@ -1040,9 +1044,25 @@ def dso_CFS(
                 }
             )
         elif rate_scenario == "transactive":
-            None
+            retail_sales_dict.update(
+                {
+                    "TransactiveSales": OtherRateSales,
+                    "TransactiveDAEnergySales": DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"]["TransactiveDAEnergyCharges"],
+                    "TransactiveRTEnergySales": DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"]["TransactiveRTEnergyCharges"],
+                    "TransactiveFixedSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"]["TransactiveFixedCharges"],
+                    "TransactiveVolumetricSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"]["TransactiveVolumetricCharges"],
+                }
+            )
         elif rate_scenario == "dsot":
-            None
+            retail_sales_dict.update(
+                {
+                    "DSOTSales": OtherRateSales,
+                    "DSOTDAEnergySales": DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"]["DSOTDAEnergyCharges"],
+                    "DSOTRTEnergySales": DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"]["DSOTRTEnergyCharges"],
+                    "DSOTFixedSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"]["DSOTFixedCharges"],
+                    "DSOTVolumetricSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"]["DSOTVolumetricCharges"],
+                }
+            )
 
         # Update the DSO cash flows composite dict
         DSO_Cash_Flows_composite.update(retail_sales_dict)

--- a/src/tesp_support/tesp_support/dsot/dso_CFS.py
+++ b/src/tesp_support/tesp_support/dsot/dso_CFS.py
@@ -62,7 +62,7 @@ def dso_CFS(
     system_case_config = case_config
 
     if rate_scenario is not None:
-        if rate_scenario == "transactive":
+        if rate_scenario in ["transactive", "dsot"]:
             TransactiveCaseFlag = 1
         else:
             TransactiveCaseFlag = 0
@@ -396,6 +396,19 @@ def dso_CFS(
             )
             RetailRTEnergy = sum(
                 DSO_Revenues_and_Energy_Sales["RetailSales"]["TransactiveSales" + c][
+                    "RetailRTEnergy" + c
+                ]
+                for c in ["Res", "Comm", "Ind"]
+            )
+        elif rate_scenario == "dsot":
+            RetailDAEnergy = sum(
+                DSO_Revenues_and_Energy_Sales["RetailSales"]["DSOTSales" + c][
+                    "RetailDAEnergy" + c
+                ]
+                for c in ["Res", "Comm", "Ind"]
+            )
+            RetailRTEnergy = sum(
+                DSO_Revenues_and_Energy_Sales["RetailSales"]["DSOTSales" + c][
                     "RetailRTEnergy" + c
                 ]
                 for c in ["Res", "Comm", "Ind"]
@@ -985,8 +998,12 @@ def dso_CFS(
             DSO_Cash_Flows["Revenues"]["RetailSales"]["TOUSales"]
         )
         elif rate_scenario == "subscription":
-            OtherRateSales = 0
+            OtherRateSales = dso_helper.returnDictSum(
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]
+        )
         elif rate_scenario == "transactive":
+            OtherRateSales = 0
+        elif rate_scenario == "dsot":
             OtherRateSales = 0
 
         # Determine the total retail sales
@@ -1013,8 +1030,18 @@ def dso_CFS(
                 }
             )
         elif rate_scenario == "subscription":
-            None
+            retail_sales_dict.update(
+                {
+                    "SubscriptionSales": OtherRateSales,
+                    "SubscriptionEnergySales": DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]["SubscriptionEnergyCharges"],
+                    "SubscriptionDemandSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]["SubscriptionDemandCharges"],
+                    "SubscriptionFixedSales": DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]["SubscriptionFixedCharges"],
+                    "SubscriptionNetDeviationCharges": DSO_Cash_Flows["Revenues"]["RetailSales"]["SubscriptionSales"]["SubscriptionFixedCharges"],
+                }
+            )
         elif rate_scenario == "transactive":
+            None
+        elif rate_scenario == "dsot":
             None
 
         # Update the DSO cash flows composite dict

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -261,13 +261,15 @@ def read_meters(
                                                               DA_retail_df['clear_type_da']).sum() + \
                                                              ((RTonehour['real_power_avg'] - temp2[
                                                                  'total_cleared_quantity']) * RThourcleartype).sum()
-            
+
             # Calculate the transactive capacity charge components, if applicable
+            # TODO: Incorporate dynamic capital costs, likely following a similar 
+            # format to that implemented for the DA and RT energy charges
+            """
             if rate_scenario == "transactive":
-                # TODO: Incorporate dynamic capital costs, likely following a similar 
-                # format to that implemented for the DA and RT energy charges
                 trans_df.loc[(each, "DA_capacity_charge"), day_name] = 0
                 trans_df.loc[(each, "RT_capacity_charge"), day_name] = 0
+            """
 
         # Calculate total energy consumption for each customer class (aka load type)
         for each in metadata['billingmeters']:
@@ -1055,8 +1057,8 @@ def calculate_consumer_bills(
     elif rate_scenario == "transactive":
         bill_components.append("transactive_DA_energy_charge")
         bill_components.append("transactive_RT_energy_charge")
-        bill_components.append("transactive_DA_capacity_charge")
-        bill_components.append("transactive_RT_capacity_charge")
+        #bill_components.append("transactive_DA_capacity_charge")
+        #bill_components.append("transactive_RT_capacity_charge")
         bill_components.append("transactive_fixed_charge")
         bill_components.append("transactive_volumetric_charge")
         bill_components.append("transactive_total_charge")
@@ -1397,6 +1399,9 @@ def calculate_consumer_bills(
 
                     # Calculate the consumer's dynamic capacity charges under the
                     # transactive tariff
+                    # TODO: Revisit later to split the DA and RT LMPs and dynamic 
+                    # capacity charges
+                    """
                     bill_df.loc[(each, "transactive_DA_capacity_charge"), m] = (
                         trans_df.loc[(each, "DA_capacity_charge"), m]
                         * trans_retail_scale
@@ -1405,6 +1410,7 @@ def calculate_consumer_bills(
                         trans_df.loc[(each, "RT_capacity_charge"), m]
                         * trans_retail_scale
                     )
+                    """
 
                     # Calculate the consumer's fixed charge under the transactive tariff
                     bill_df.loc[
@@ -1421,8 +1427,8 @@ def calculate_consumer_bills(
                     bill_df.loc[(each, "transactive_total_charge"), m] = (
                         bill_df.loc[(each, "transactive_DA_energy_charge"), m]
                         + bill_df.loc[(each, "transactive_RT_energy_charge"), m]
-                        + bill_df.loc[(each, "transactive_DA_capacity_charge"), m]
-                        + bill_df.loc[(each, "transactive_RT_capacity_charge"), m]
+                        #+ bill_df.loc[(each, "transactive_DA_capacity_charge"), m]
+                        #+ bill_df.loc[(each, "transactive_RT_capacity_charge"), m]
                         + bill_df.loc[(each, "transactive_fixed_charge"), m]
                         + bill_df.loc[(each, "transactive__charge"), m]
                     )
@@ -2824,7 +2830,7 @@ def DSO_rate_making(
         case_name="",
         iterate=False,
         rate_scenario=None,
-    ):
+):
     """ Main function to call for calculating the customer energy consumption, monthly bills, and tariff adjustments to
     ensure revenue matches expenses.  Saves meter and bill dataframes to a hdf5 file.
     Args:

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -3501,7 +3501,7 @@ def DSO_rate_making(
                 billsum_df.loc[("total", "flat_energy_purchased"), "sum"]
                 + billsum_df.loc[("total", "dsot_energy_purchased"), "sum"]
             )
-            DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTeSales"] = {
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTSales"] = {
                 "DSOTDAEnergyCharges": billsum_df.loc[("total", "dsot_DA_energy_charge"), "sum"] / 1000, # $k
                 "DSOTRTEnergyCharges": billsum_df.loc[("total", "dsot_RT_energy_charge"), "sum"] / 1000, # $k
                 "DSOTFixedCharges": billsum_df.loc[("total", "dsot_fixed_charge"), "sum"] / 1000, # $k

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -3418,9 +3418,95 @@ def DSO_rate_making(
                 "SubscriptionNetDeviationCharges": billsum_df.loc[("total", "subscription_net_deviation_charge"), "sum"] / 1000, # $k
             }
         elif rate_scenario == "transactive":
-            None
+            DSO_Revenues_and_Energy_Sales["RetailSales"]["TransactiveSales"] = {
+                "TransactiveSalesRes": {
+                    "TransactiveEnergySalesRes": billsum_df.loc[("residential", "transactive_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "TransactiveDAEnergyChargesRes": billsum_df.loc[("residential", "transactive_DA_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveRTEnergyChargesRes": billsum_df.loc[("residential", "transactive_RT_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveFixedChargesRes": billsum_df.loc[("residential", "transactive_fixed_charge"), "sum"] / 1000, # $k
+                    "TransactiveVolumetricChargeRes": billsum_df.loc[("residential", "transactive_volumetric_charge"), "sum"] / 1000, # $k
+                    "TransactiveAveragePriceRes": billsum_df.loc[("residential", "transactive_average_price"), "sum"], # $/kW-hr
+                },
+                "TransactiveSalesComm": {
+                    "TransactiveEnergySalesComm": billsum_df.loc[("commercial", "transactive_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "TransactiveDAEnergyChargesComm": billsum_df.loc[("commercial", "transactive_DA_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveRTEnergyChargesComm": billsum_df.loc[("commercial", "transactive_RT_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveFixedChargesComm": billsum_df.loc[("commercial", "transactive_fixed_charge"), "sum"] / 1000, # $k
+                    "TransactiveVolumetricChargeComm": billsum_df.loc[("commercial", "transactive_volumetric_charge"), "sum"] / 1000, # $k
+                    "TransactiveAveragePriceComm": billsum_df.loc[("commercial", "transactive_average_price"), "sum"], # $/kW-hr
+                },
+                "TransactiveSalesInd": {
+                    "TransactiveEnergySalesInd": billsum_df.loc[("industrial", "transactive_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "TransactiveDAEnergyChargesInd": billsum_df.loc[("industrial", "transactive_DA_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveRTEnergyChargesInd": billsum_df.loc[("industrial", "transactive_RT_energy_charge"), "sum"] / 1000, # $k
+                    "TransactiveFixedChargesInd": billsum_df.loc[("industrial", "transactive_fixed_charge"), "sum"] / 1000, # $k
+                    "TransactiveVolumetricChargeInd": billsum_df.loc[("industrial", "transactive_volumetric_charge"), "sum"] / 1000, # $k
+                    "TransactiveAveragePriceInd": billsum_df.loc[("industrial", "transactive_average_price"), "sum"], # $/kW-hr
+                },
+            }
+            DSO_Revenues_and_Energy_Sales["EnergySold"] += billsum_df.loc[("total", "transactive_energy_purchased"), "sum"] / 1000 # Energy Sold in MW-hr
+            for m in billsum_df:
+                if m != "sum":
+                    DSO_Revenues_and_Energy_Sales["EnergySoldMonthly"][m] += billsum_df.loc[("total", "transactive_energy_purchased"), m] / 1000
+            DSO_Revenues_and_Energy_Sales["RequiredRevenue"] += billsum_df.loc[("total", "transactive_total_charge"), "sum"] / 1000, # Energy charges in $k
+            DSO_Revenues_and_Energy_Sales["EffectiveCostRetailEnergy"] = (
+                billsum_df.loc[("total", "flat_total_charge"), "sum"]
+                + billsum_df.loc[("total", "transactive_total_charge"), "sum"]
+            ) / (
+                billsum_df.loc[("total", "flat_energy_purchased"), "sum"]
+                + billsum_df.loc[("total", "transactive_energy_purchased"), "sum"]
+            )
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["TransactiveSales"] = {
+                "TransactiveDAEnergyCharges": billsum_df.loc[("total", "transactive_DA_energy_charge"), "sum"] / 1000, # $k
+                "TransactiveRTEnergyCharges": billsum_df.loc[("total", "transactive_RT_energy_charge"), "sum"] / 1000, # $k
+                "TransactiveFixedCharges": billsum_df.loc[("total", "transactive_fixed_charge"), "sum"] / 1000, # $k
+                "TransactiveVolumetricCharges": billsum_df.loc[("total", "transactive_volumetric_charge"), "sum"] / 1000, # $k
+            }
         elif rate_scenario == "dsot":
-            None
+            DSO_Revenues_and_Energy_Sales["RetailSales"]["DSOTSales"] = {
+                "DSOTSalesRes": {
+                    "DSOTEnergySalesRes": billsum_df.loc[("residential", "dsot_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "DSOTDAEnergyChargesRes": billsum_df.loc[("residential", "dsot_DA_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTRTEnergyChargesRes": billsum_df.loc[("residential", "dsot_RT_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTFixedChargesRes": billsum_df.loc[("residential", "dsot_fixed_charge"), "sum"] / 1000, # $k
+                    "DSOTVolumetricChargeRes": billsum_df.loc[("residential", "dsot_volumetric_charge"), "sum"] / 1000, # $k
+                    "DSOTAveragePriceRes": billsum_df.loc[("residential", "dsot_average_price"), "sum"], # $/kW-hr
+                },
+                "DSOTSalesComm": {
+                    "DSOTEnergySalesComm": billsum_df.loc[("commercial", "dsot_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "DSOTDAEnergyChargesComm": billsum_df.loc[("commercial", "dsot_DA_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTRTEnergyChargesComm": billsum_df.loc[("commercial", "dsot_RT_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTFixedChargesComm": billsum_df.loc[("commercial", "dsot_fixed_charge"), "sum"] / 1000, # $k
+                    "DSOTVolumetricChargeComm": billsum_df.loc[("commercial", "dsot_volumetric_charge"), "sum"] / 1000, # $k
+                    "DSOTAveragePriceComm": billsum_df.loc[("commercial", "dsot_average_price"), "sum"], # $/kW-hr
+                },
+                "DSOTSalesInd": {
+                    "DSOTEnergySalesInd": billsum_df.loc[("industrial", "dsot_energy_purchased"), "sum"] / 1000, # MW-hr/year
+                    "DSOTDAEnergyChargesInd": billsum_df.loc[("industrial", "dsot_DA_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTRTEnergyChargesInd": billsum_df.loc[("industrial", "dsot_RT_energy_charge"), "sum"] / 1000, # $k
+                    "DSOTFixedChargesInd": billsum_df.loc[("industrial", "dsot_fixed_charge"), "sum"] / 1000, # $k
+                    "DSOTVolumetricChargeInd": billsum_df.loc[("industrial", "dsot_volumetric_charge"), "sum"] / 1000, # $k
+                    "DSOTAveragePriceInd": billsum_df.loc[("industrial", "dsot_average_price"), "sum"], # $/kW-hr
+                },
+            }
+            DSO_Revenues_and_Energy_Sales["EnergySold"] += billsum_df.loc[("total", "dsot_energy_purchased"), "sum"] / 1000 # Energy Sold in MW-hr
+            for m in billsum_df:
+                if m != "sum":
+                    DSO_Revenues_and_Energy_Sales["EnergySoldMonthly"][m] += billsum_df.loc[("total", "dsot_energy_purchased"), m] / 1000
+            DSO_Revenues_and_Energy_Sales["RequiredRevenue"] += billsum_df.loc[("total", "dsot_total_charge"), "sum"] / 1000, # Energy charges in $k
+            DSO_Revenues_and_Energy_Sales["EffectiveCostRetailEnergy"] = (
+                billsum_df.loc[("total", "flat_total_charge"), "sum"]
+                + billsum_df.loc[("total", "dsot_total_charge"), "sum"]
+            ) / (
+                billsum_df.loc[("total", "flat_energy_purchased"), "sum"]
+                + billsum_df.loc[("total", "dsot_energy_purchased"), "sum"]
+            )
+            DSO_Cash_Flows["Revenues"]["RetailSales"]["DSOTeSales"] = {
+                "DSOTDAEnergyCharges": billsum_df.loc[("total", "dsot_DA_energy_charge"), "sum"] / 1000, # $k
+                "DSOTRTEnergyCharges": billsum_df.loc[("total", "dsot_RT_energy_charge"), "sum"] / 1000, # $k
+                "DSOTFixedCharges": billsum_df.loc[("total", "dsot_fixed_charge"), "sum"] / 1000, # $k
+                "DSOTVolumetricCharges": billsum_df.loc[("total", "dsot_volumetric_charge"), "sum"] / 1000, # $k
+            }
 
     return DSO_Cash_Flows, DSO_Revenues_and_Energy_Sales, tariff, surplus
 

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1212,6 +1212,7 @@ def calculate_consumer_bills(
                 elif rate_scenario == "subscription":
                     # Calculate the consumer's net deviation charge under the
                     # subscription rate
+                    # TODO: Incorporate dynamic capital cost recovery price
                     bill_df.loc[(each, "subscription_net_deviation_charge"), m] = sum(
                         da_lmp_stats.loc[str(t), "da_lmp" + dso_num]
                         * (demand_df.loc[t, each] - bl_demand_df.loc[t, each])
@@ -2163,6 +2164,7 @@ def calculate_tariff_prices(
 
                     # Update the total revenue from the net deviation charges for each
                     # residential and commercial consumer during each season
+                    # TODO: Incorporate dynamic capital cost recovery price
                     rev_net_deviation_charge_sub_rc[s] += sum(
                         da_lmp_stats.loc[str(t), "da_lmp" + dso_num]
                         * (demand_df[s].loc[t, each] - bl_demand_df[s].loc[t, each])
@@ -2248,6 +2250,7 @@ def calculate_tariff_prices(
 
                     # Update the total revenue from the net deviation charges for each
                     # industrial consumer during each season
+                    # TODO: Incorporate dynamic capital cost recovery price
                     rev_net_deviation_charge_sub_i[s] += sum(
                         da_lmp_stats.loc[str(t), "da_lmp" + dso_num]
                         * (demand_df[s].loc[t, each] - bl_demand_df[s].loc[t, each])
@@ -2358,6 +2361,7 @@ def calculate_tariff_prices(
                     for s in seasons_dict:
                         # Update the total revenue from the net deviation charges for 
                         # subscription consumers during each season
+                        # TODO: Incorporate dynamic capital cost recovery price
                         rev_net_deviation_charge_sub[s] += sum(
                             da_lmp_stats.loc[str(t), "da_lmp" + dso_num]
                             * (demand_df[s].loc[t, each] - bl_demand_df[s].loc[t, each])

--- a/src/tesp_support/tesp_support/dsot/dso_rate_making.py
+++ b/src/tesp_support/tesp_support/dsot/dso_rate_making.py
@@ -1538,12 +1538,14 @@ def calculate_tariff_prices(
                     "commercial",
                 ]:
                     # Update the total consumption for each consumer during each season
-                    for k in tou_params["DSO_" + dso_num]["periods"].keys():
-                        total_weighted_consumption_tou_rc[s] += sum(
+                    total_weighted_consumption_tou_rc[s] += sum(
+                        sum(
                             tou_params["DSO_" + dso_num][m]["periods"][k]["ratio"]
                             * meter_df.loc[(each, k + "_kwh"), m]
                             for m in seasons_dict[s]
                         )
+                        for k in tou_params["DSO_" + dso_num]["periods"].keys()
+                    )
 
                     # Specify the demand charge based on the consumer's sector type
                     demand_charge = tariff["DSO_" + dso_num][
@@ -1577,12 +1579,14 @@ def calculate_tariff_prices(
                         )
 
             # Calculate the necessary rate components for industrial consumers
-            for k in tou_params["DSO_" + dso_num]["periods"].keys():
-                total_weighted_consumption_tou_i[s] += sum(
+            total_weighted_consumption_tou_i[s] += sum(
+                sum(
                     tou_params["DSO_" + dso_num][m]["periods"][k]["ratio"]
-                    * energy_sum_df.loc[("industrial", k + "_kwh"), m]\
+                    * energy_sum_df.loc[("industrial", k + "_kwh"), m]
                     for m in seasons_dict[s]
                 )
+                for k in tou_params["DSO_" + dso_num]["periods"].keys()
+            )
             rev_demand_charge_tou_i[s] = tariff["DSO_" + dso_num]["industrial"][
                 "demand_charge"
             ] * sum(
@@ -1640,31 +1644,33 @@ def calculate_tariff_prices(
             ]:
                 if metadata["billingmeters"][each]["cust_participating"]:
                     for s in seasons_dict:
-                        for k in tou_params["DSO_" + dso_num][m]["periods"].keys():
-                            # Update the total revenue from energy charges for 
-                            # time-of-use consumers during each season
-                            rev_energy_charge_tou[s] += sum(
+                        # Update the total revenue from energy charges for time-of-use
+                        # consumers during each season
+                        rev_energy_charge_tou[s] += sum(
+                            sum(
                                 prices["tou_rate_" + s]
                                 * tou_params["DSO_" + dso_num][m]["periods"][k]["ratio"]
                                 * meter_df.loc[(each, k + "_kwh"), m]
                                 for m in seasons_dict[s]
                             )
+                            for k in tou_params["DSO_" + dso_num][m]["periods"].keys()
+                        )
 
-                            # Calculate the consumer's tier credit (due to the declining 
-                            # block) rate, if the consumer is eligible
-                            if metadata["billingmeters"][each]["tariff_class"] in [
-                                #"residential",
-                                "commercial",
-                            ]:
-                                rev_energy_charge_tou[s] += sum(
-                                    calculate_tier_credit(
-                                        dso_num,
-                                        metadata["billingmeters"][each]["tariff_class"],
-                                        tariff,
-                                        meter_df.loc[(each, "kw-hr"), m],
-                                    )
-                                    for m in seasons_dict[s]
+                        # Calculate the consumer's tier credit (due to the declining 
+                        # block) rate, if the consumer is eligible
+                        if metadata["billingmeters"][each]["tariff_class"] in [
+                            #"residential",
+                            "commercial",
+                        ]:
+                            rev_energy_charge_tou[s] += sum(
+                                calculate_tier_credit(
+                                    dso_num,
+                                    metadata["billingmeters"][each]["tariff_class"],
+                                    tariff,
+                                    meter_df.loc[(each, "kw-hr"), m],
                                 )
+                                for m in seasons_dict[s]
+                            )
 
                         # Specify the demand charge based on the consumer's sector type
                         demand_charge = tariff["DSO_" + dso_num][


### PR DESCRIPTION
This PR largely incorporates functionality that allows for bills to be calculated and expense-recovering prices to be determined for the transactive and DSO+T rates. There are also minor changes included that help address small bugs. As such, the majority of this PR's changes live within `dso_rate_making.py`.